### PR TITLE
Improve HEIF/AVIF support and error handling

### DIFF
--- a/classes/class-format-support.php
+++ b/classes/class-format-support.php
@@ -9,32 +9,35 @@
 namespace NotGlossy\VipsImageEditorFFI;
 
 /**
- * Helper class to check for HEIF/HEIC support
+ * Helper class to check for image format support via libvips.
  */
 class Format_Support {
 
 	/**
-	 * Check if the server's libvips has HEIF support
+	 * Map of MIME types to file extensions used to probe libvips for format support.
 	 *
-	 * @return bool Whether HEIF is supported
+	 * @var array<string, string>
 	 */
-	public static function has_heif_support() {
-		try {
-			// Try to find the heif loader in vips.
-			$all_loaders = \Jcupitt\Vips\Image::findLoad( '.heic' );
-
-			// If we don't get an exception and the loader exists, heif is supported.
-			return ! empty( $all_loaders );
-		} catch ( \Exception $e ) {
-			return false;
-		}
-	}
+	private static $mime_to_ext = array(
+		'image/jpeg' => '.jpg',
+		'image/png'  => '.png',
+		'image/gif'  => '.gif',
+		'image/webp' => '.webp',
+		'image/heic' => '.heic',
+		'image/heif' => '.heif',
+		'image/avif' => '.avif',
+		'image/jxl'  => '.jxl',
+	);
 
 	/**
-	 * Check if a specific MIME type is supported by the current vips installation
+	 * Check if a specific MIME type is supported by the current vips installation.
+	 *
+	 * Uses vips_foreign_find_save_buffer() to query libvips for available format
+	 * support by suffix matching. This is more reliable than findLoad() which
+	 * requires an actual file to sniff.
 	 *
 	 * @param string $mime_type The MIME type to check.
-	 * @return bool Whether the format is supported
+	 * @return bool Whether the format is supported.
 	 */
 	public static function is_format_supported( $mime_type ) {
 		static $supported_cache = array();
@@ -46,31 +49,43 @@ class Format_Support {
 
 		$supported = false;
 
-		switch ( $mime_type ) {
-			case 'image/jpeg':
-			case 'image/png':
-			case 'image/gif':
-			case 'image/webp':
-				$supported = true;
-				break;
+		if ( isset( self::$mime_to_ext[ $mime_type ] ) ) {
+			$ext = self::$mime_to_ext[ $mime_type ];
+			try {
+				$saver     = \Jcupitt\Vips\FFI::vips()->vips_foreign_find_save_buffer( $ext );
+				$supported = ! empty( $saver );
 
-			case 'image/heic':
-			case 'image/heif':
-				$supported = self::has_heif_support();
-				break;
-
-			case 'image/avif':
-				$supported = true;
-				break;
-
-			case 'image/jxl':
-				$supported = true;
-				break;
+				// Some libvips versions don't register .avif as a buffer saver suffix.
+				// Fall back to testing actual AV1 compression with a tiny image, since
+				// the HEIF module may exist but only support HEVC (not AV1).
+				if ( ! $supported && 'image/avif' === $mime_type ) {
+					$supported = self::test_heif_compression( \Jcupitt\Vips\ForeignHeifCompression::AV1 );
+				}
+			} catch ( \Exception $e ) {
+				$supported = false;
+			}
 		}
 
 		// Cache the result.
 		$supported_cache[ $mime_type ] = $supported;
 
 		return $supported;
+	}
+
+	/**
+	 * Test if a specific HEIF compression type is supported by attempting
+	 * to encode a tiny 1x1 image.
+	 *
+	 * @param string $compression A ForeignHeifCompression enum value (e.g. 'av1', 'hevc').
+	 * @return bool Whether the compression type is supported.
+	 */
+	private static function test_heif_compression( $compression ) {
+		try {
+			$test_image = \Jcupitt\Vips\Image::black( 1, 1 );
+			$test_image->heifsave_buffer( array( 'compression' => $compression ) );
+			return true;
+		} catch ( \Exception $e ) {
+			return false;
+		}
 	}
 }

--- a/classes/class-image-editor-vips-ffi.php
+++ b/classes/class-image-editor-vips-ffi.php
@@ -155,7 +155,10 @@ class Image_Editor_Vips_FFI extends \WP_Image_Editor {
 			return true;
 		}
 		try {
-			$resized     = $this->_resize( $max_w, $max_h, $crop );
+			$resized = $this->_resize( $max_w, $max_h, $crop );
+			if ( is_wp_error( $resized ) ) {
+				return $resized;
+			}
 			$this->image = $resized;
 			return true;
 		} catch ( Exception $exception ) {
@@ -171,7 +174,7 @@ class Image_Editor_Vips_FFI extends \WP_Image_Editor {
 	 * @param bool|array $crop Optional. Whether to crop the image. Default false.
 	 * @return resource|\WP_Error
 	 */
-	protected function _resize( $max_w, $max_h, $crop = false ) {
+	protected function _resize( $max_w, $max_h, $crop = false ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- overrides WP_Image_Editor::_resize().
 		$dims = image_resize_dimensions( $this->size['width'], $this->size['height'], $max_w, $max_h, $crop );
 		if ( ! $dims ) {
 			return new \WP_Error( 'error_getting_dimensions', __( 'Could not calculate resized image dimensions', 'vips-image-editor' ), $this->file );
@@ -430,7 +433,16 @@ class Image_Editor_Vips_FFI extends \WP_Image_Editor {
 	 * }
 	 */
 	public function save( $destfilename = null, $mime_type = null ) {
-		$saved = $this->_save( $this->image, $destfilename, $mime_type );
+		try {
+			$saved = $this->_save( $this->image, $destfilename, $mime_type );
+		} catch ( \Throwable $e ) {
+			/*
+			* Return false instead of WP_Error to work around wp_save_image()
+			* not handling WP_Error from wp_save_image_file().
+			* See: https://core.trac.wordpress.org/ticket/64902#ticket
+			*/
+			return false;
+		}
 
 		if ( ! is_wp_error( $saved ) ) {
 			$this->file      = $saved['path'];
@@ -450,7 +462,7 @@ class Image_Editor_Vips_FFI extends \WP_Image_Editor {
 	 * @param string   $filename Optional. The destination filename. Default null.
 	 * @param string   $mime_type Optional. The mime type of the image. Default null.
 	 */
-	protected function _save( $image, $filename = null, $mime_type = null ) {
+	protected function _save( $image, $filename = null, $mime_type = null ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- overrides WP_Image_Editor::_save().
 		list( $filename, $extension, $mime_type ) = $this->get_output_format( $filename, $mime_type );
 
 		if ( ! $filename ) {
@@ -488,7 +500,27 @@ class Image_Editor_Vips_FFI extends \WP_Image_Editor {
 			$wp_filesystem->mkdir( $directory );
 		}
 
-		$image->writeToFile( $filename, $parameters );
+		// Use explicit heifsave for AVIF/HEIC/HEIF to avoid suffix registration issues
+		// where some libvips builds don't register .avif for the file saver.
+		if ( 'image/avif' === $mime_type ) {
+			$image->heifsave(
+				$filename,
+				array(
+					'Q'           => $this->get_quality(),
+					'compression' => Vips\ForeignHeifCompression::AV1,
+				)
+			);
+		} elseif ( 'image/heic' === $mime_type || 'image/heif' === $mime_type ) {
+			$image->heifsave(
+				$filename,
+				array(
+					'Q'           => $this->get_quality(),
+					'compression' => Vips\ForeignHeifCompression::HEVC,
+				)
+			);
+		} else {
+			$image->writeToFile( $filename, $parameters );
+		}
 
 		// Set correct file permissions.
 		$stat  = stat( dirname( $filename ) );
@@ -533,78 +565,83 @@ class Image_Editor_Vips_FFI extends \WP_Image_Editor {
 			return false;
 		}
 
-		switch ( $mime_type ) {
-			case 'image/png':
-				header( 'Content-Type: image/png' );
-				echo $this->image->writeToBuffer( '.png' ); // phpcs:ignore
-				return true;
+		try {
+			switch ( $mime_type ) {
+				case 'image/png':
+					header( 'Content-Type: image/png' );
+					echo $this->image->writeToBuffer( '.png' ); // phpcs:ignore
+					return true;
 
-			case 'image/jpeg':
-				header( 'Content-Type: image/jpeg' );
-				echo $this->image->writeToBuffer( // phpcs:ignore
-					'.jpg',
-					array(
-						'Q' => $this->get_quality(), // phpcs:ignore
-					)
-				);
-				return true;
+				case 'image/jpeg':
+					header( 'Content-Type: image/jpeg' );
+					echo $this->image->writeToBuffer( // phpcs:ignore
+						'.jpg',
+						array(
+							'Q' => $this->get_quality(), // phpcs:ignore
+						)
+					);
+					return true;
 
-			case 'image/gif':
-				header( 'Content-Type: image/gif' );
-				echo $this->image->writeToBuffer( '.gif' ); // phpcs:ignore
-				return true;
+				case 'image/gif':
+					header( 'Content-Type: image/gif' );
+					echo $this->image->writeToBuffer( '.gif' ); // phpcs:ignore
+					return true;
 
-			case 'image/webp':
-				header( 'Content-Type: image/webp' );
-				echo $this->image->writeToBuffer( // phpcs:ignore
-					'.webp',
-					array(
-						'Q' => $this->get_quality(), // phpcs:ignore
-					)
-				);
-				return true;
+				case 'image/webp':
+					header( 'Content-Type: image/webp' );
+					echo $this->image->writeToBuffer( // phpcs:ignore
+						'.webp',
+						array(
+							'Q' => $this->get_quality(), // phpcs:ignore
+						)
+					);
+					return true;
 
-			case 'image/avif':
-				header( 'Content-Type: image/avif' );
-				echo $this->image->writeToBuffer( // phpcs:ignore
-					'.avif',
-					array(
-						'Q' => $this->get_quality(), // phpcs:ignore
-					)
-				);
-				return true;
-			case 'image/heic':
-				header( 'Content-Type: image/heic' );
-				echo $this->image->writeToBuffer( // phpcs:ignore
-					'.heic',
-					array(
-						'Q' => $this->get_quality(), // phpcs:ignore
-					)
-				);
-				return true;
+				case 'image/avif':
+					header( 'Content-Type: image/avif' );
+					echo $this->image->heifsave_buffer( // phpcs:ignore
+						array(
+							'Q'           => $this->get_quality(), // phpcs:ignore
+							'compression' => Vips\ForeignHeifCompression::AV1, // phpcs:ignore
+						)
+					);
+					return true;
+				case 'image/heic':
+					header( 'Content-Type: image/heic' );
+					echo $this->image->heifsave_buffer( // phpcs:ignore
+						array(
+							'Q'           => $this->get_quality(), // phpcs:ignore
+							'compression' => Vips\ForeignHeifCompression::HEVC, // phpcs:ignore
+						)
+					);
+					return true;
 
-			case 'image/heif':
-				header( 'Content-Type: image/heif' );
-				echo $this->image->writeToBuffer( // phpcs:ignore
-					'.heif',
-					array(
-						'Q' => $this->get_quality(), // phpcs:ignore
-					)
-				);
-				return true;
+				case 'image/heif':
+					header( 'Content-Type: image/heif' );
+					echo $this->image->heifsave_buffer( // phpcs:ignore
+						array(
+							'Q'           => $this->get_quality(), // phpcs:ignore
+							'compression' => Vips\ForeignHeifCompression::HEVC, // phpcs:ignore
+						)
+					);
+					return true;
 
-			case 'image/jxl':
-				header( 'Content-Type: image/jxl' );
-				echo $this->image->writeToBuffer( // phpcs:ignore
-					'.jxl',
-					array(
-						'Q' => $this->get_quality(), // phpcs:ignore
-					)
-				);
-				return true;
+				case 'image/jxl':
+					header( 'Content-Type: image/jxl' );
+					echo $this->image->writeToBuffer( // phpcs:ignore
+						'.jxl',
+						array(
+							'Q' => $this->get_quality(), // phpcs:ignore
+						)
+					);
+					return true;
 
+			}
+
+			return false;
+		} catch ( \Throwable $e ) {
+			return false;
 		}
-		return false;
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "jcupitt/vips": "2.5.0",
+        "jcupitt/vips": "2.6.1",
          "ext-ffi": "*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc66a0ac746da3cecba414bc6240f053",
+    "content-hash": "778e1917c66435e1dbd5e4f8640190bd",
     "packages": [
         {
             "name": "jcupitt/vips",
-            "version": "v2.5.0",
+            "version": "v2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libvips/php-vips.git",
-                "reference": "a54c1cceea581b592a199edd61a7c06f44a24c08"
+                "reference": "6dbba1bb3a4ba1e39edb71016a2aa6da5bff32ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libvips/php-vips/zipball/a54c1cceea581b592a199edd61a7c06f44a24c08",
-                "reference": "a54c1cceea581b592a199edd61a7c06f44a24c08",
+                "url": "https://api.github.com/repos/libvips/php-vips/zipball/6dbba1bb3a4ba1e39edb71016a2aa6da5bff32ee",
+                "reference": "6dbba1bb3a4ba1e39edb71016a2aa6da5bff32ee",
                 "shasum": ""
             },
             "require": {
@@ -63,9 +63,9 @@
             ],
             "support": {
                 "issues": "https://github.com/libvips/php-vips/issues",
-                "source": "https://github.com/libvips/php-vips/tree/v2.5.0"
+                "source": "https://github.com/libvips/php-vips/tree/v2.6.1"
             },
-            "time": "2025-04-04T17:10:13+00:00"
+            "time": "2025-12-10T14:03:20+00:00"
         },
         {
             "name": "psr/log",
@@ -2848,5 +2848,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/vips-image-editor-ffi.php
+++ b/vips-image-editor-ffi.php
@@ -76,3 +76,24 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\\init' );
 
 // Use WordPress add_filter function from global namespace.
 \add_filter( 'wp_image_editors', __NAMESPACE__ . '\\image_editors_add_vips_ffi' );
+
+/**
+ * Convert unsupported output formats to JPEG.
+ *
+ * When a format like AVIF cannot be encoded by any available image editor
+ * (e.g. libvips lacks AV1 support), this filter converts the output to JPEG
+ * so that image editing operations (scale, rotate, crop) still succeed.
+ *
+ * @param array  $output_format Map of input mime types to output mime types.
+ * @param string $filename     The original image filename.
+ * @param string $mime_type    The original image mime type.
+ * @return array Modified output format map.
+ */
+function maybe_convert_unsupported_formats( $output_format, $filename, $mime_type ) {
+	// Only convert formats that our editor can't save.
+	if ( class_exists( __NAMESPACE__ . '\\Format_Support' ) && ! Format_Support::is_format_supported( $mime_type ) ) {
+		$output_format[ $mime_type ] = 'image/jpeg';
+	}
+	return $output_format;
+}
+\add_filter( 'image_editor_output_format', __NAMESPACE__ . '\\maybe_convert_unsupported_formats', 10, 3 );


### PR DESCRIPTION
This fixes issues that arise when an image format is not supported by VIPS in the WordPress environment. It also provides a workaround for a bug in WordPress core ([#64902](https://core.trac.wordpress.org/ticket/64902#ticket)) where a fatal error occurs when an image editor returns an error.

- Update image format detection mechanism to return true/false based on `vips_foreign_find_save_buffer()`
- Add override to `save()` function to check for `WP_Error` and return `false` instead to work around core bug
- Add additional format detection for HEIF/AVIF handling
- Enable fallback to imagick or GD for unsupported VIPS formats
- Update php-vips version
