### PR TITLE
CI: add security audit, caching; require PHP 8.1

### DIFF
--- a/.github/workflows/php-quality.yaml
+++ b/.github/workflows/php-quality.yaml
@@ -1,17 +1,17 @@
-name: PHP Code Quality
+name: PHP Code Quality & Security
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   psalm:
     name: Psalm Static Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -19,6 +19,17 @@ jobs:
           php-version: '8.1'
           extensions: ffi
           tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
@@ -30,7 +41,7 @@ jobs:
     name: WordPress Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -39,8 +50,49 @@ jobs:
           extensions: ffi
           tools: composer:v2
 
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
       - name: Run PHPCS
-        run: ./vendor/bin/phpcs .
+        run: ./vendor/bin/phpcs --standard=phpcs.xml.dist
+
+  security:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: ffi
+          tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Composer Audit
+        run: composer audit

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.1",
         "jcupitt/vips": "2.6.1",
          "ext-ffi": "*"
     },
@@ -24,7 +24,7 @@
     },
     "config": {
         "platform": {
-            "php": "8.2"
+            "php": "8.1"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -35,7 +35,7 @@
     <rule ref="WordPress-Docs"/>
 
     <!-- Check for PHP cross-version compatibility -->
-    <config name="testVersion" value="8.2-"/>
+    <config name="testVersion" value="8.1-"/>
     <rule ref="PHPCompatibilityWP"/>
 
     <!-- Rules customization -->


### PR DESCRIPTION
- Update GitHub Actions and PHP settings: rename workflow to include Security, switch branch filters to master, bump actions/checkout to v4, and add Composer cache steps (actions/cache@v4) to psalm and phpcs jobs to speed installs.
- Specify PHPCS standard when running phpcs and add a new security job that runs composer audit. 
- Lower project PHP requirement and platform to 8.1 in composer.json and update PHPCompatibility testVersion to 8.1- in phpcs.xml.dist to ensure CI and linting target PHP 8.1 compatibility.