### PR TITLE
Load Composer autoloader immediately

### DIFF
--- a/vips-image-editor-ffi.php
+++ b/vips-image-editor-ffi.php
@@ -23,6 +23,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit();
 }
 
+// Load Composer autoloader immediately so classes are available when any hook fires,
+// regardless of which plugins_loaded callback runs first.
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require __DIR__ . '/vendor/autoload.php';
+}
+
 add_action(
 	'admin_notices',
 	function () {
@@ -61,11 +67,6 @@ function image_editors_add_vips_ffi( $editors ) {
  * Initialize the plugin
  */
 function init() {
-
-	// Check if we are using local Composer.
-	if ( file_exists( __DIR__ . '/vendor' ) ) {
-		require __DIR__ . '/vendor/autoload.php';
-	}
 
 	// Include Format_Support helper class.
 	include_once __DIR__ . '/classes/class-format-support.php';


### PR DESCRIPTION
I installed this and started getting Fatal Errors when loading the wp admin backend. It is because some plugins load 

Here's a diagnostic from Claude:

The vendor directory is present. The issue is hook ordering. Here's what's happening:

1. WordPress loads plugins alphabetically. buddyboss-platform loads before vips-image-editor-ffi.
2. The vips plugin registers the wp_image_editors filter immediately at file-load time (not in a hook).
3. But the autoloader (vendor/autoload.php) is loaded only in a plugins_loaded callback (init()).
4. BuddyBoss fires _wp_image_editor_choose() during its own plugins_loaded callback, which runs before the vips plugin's plugins_loaded callback (alphabetical order: b before v).
5. So when test() is called and tries to use Jcupitt\Vips\FFI, the autoloader hasn't been registered yet.

The fix: require the autoloader immediately at plugin load time, not inside a deferred hook. 

An alternative that we could implement, if you prefer, is just change the load priority eg 

Change

`add_action( 'plugins_loaded', __NAMESPACE__ . '\\init' );`

to

`add_action( 'plugins_loaded', __NAMESPACE__ . '\\init', -999 );`

Ive confirmed that that fixes the issue as well, but it feels much hackier